### PR TITLE
WIP: ENH: Added Presets for CMake builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ CMakeLists.txt.user*
 
 # Ignore testing temporary files
 Testing/Temporary/
+
+# Ignore user generated CMAKE presets
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ set(ITK_USE_FILE "${ITK_CONFIG_CMAKE_DIR}/UseITK.cmake")
 # to remote module examples which are set up as independent projects that can be copied
 # outside of their original project and used without any modification.
 configure_file(CMake/ITKInternalConfig.cmake ${ITK_BINARY_DIR}/CMakeTmp/ITKConfig.cmake COPYONLY)
+# Copy presets to build directory so they can be used more easily for `cmake --build` & `ctest` steps
+configure_file(CMakePresets.json ${ITK_BINARY_DIR}/CMakePresets.json COPYONLY)
 
 
 include(CMakeDependentOption)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,165 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 2,
+    "minor": 8,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "common",
+      "displayName": "Common Build",
+      "description": "Base Build for common dashboard requirements. Must be inherited.",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_GENERATOR": {
+          "type": "STRING",
+          "value": "Ninja"
+        },
+        "CTEST_USE_LAUNCHERS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "DART_TESTING_TIMEOUT": {
+          "type": "STRING",
+          "value": "1500"
+        },
+        "ExternalData_OBJECT_STORES": {
+          "type": "STRING",
+          "value": "$env{ExternalData_OBJECT_STORES}"
+        },
+        "MAXIMUM_NUMBER_OF_HEADERS": {
+          "type": "STRING",
+          "value": "35"
+        },
+        "ITK_USE_EIGEN_MPL2_ONLY": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "MinSizeRel"
+        }
+      }
+    },
+    {
+      "name": "circleci",
+      "displayName": "CircleCI Environment",
+      "description": "This preset exactly mimics the CMake environment used for CircleCI build tests.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}-build-circleci",
+      "inherits": "common",
+      "cacheVariables": {
+        "BUILD_DOCUMENTATION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "BUILD_SHARED_LIBS": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "BUILD_TESTING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "Module_ITKReview": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ITK_USE_KWSTYLE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ITK_BUILD_DEFAULT_MODULES": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ITK_COMPUTER_MEMORY_SIZE": {
+          "type": "STRING",
+          "value": "3.5"
+        }
+      }
+    },
+
+    {
+      "name": "circleci-distcc",
+      "displayName": "CircleCI Environment",
+      "description": "This preset exactly mimics the CMake environment used for CircleCI build tests with DISTCC.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}-build-circleci",
+      "inherits": "circleci",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER_LAUNCHER": {
+          "type": "STRING",
+          "value": "distcc"
+        },
+        "CMAKE_C_COMPILER_LAUNCHER": {
+          "type": "STRING",
+          "value": "distcc"
+        }
+      }
+    },
+
+    {
+      "name": "azure",
+      "displayName": "Azure Environment",
+      "description": "This preset exactly mimics the CMake environment used for Azure build tests.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}-build-azure",
+      "inherits": "common",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ITK_WRAP_PYTHON": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
+      }
+    }
+
+  ],
+  "buildPresets": [
+    {
+      "name": "circleci",
+      "jobs": 3,
+      "configurePreset": "circleci"
+    },
+    {
+      "name": "azure",
+      "jobs": 3,
+      "configurePreset": "azure"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "circleci",
+      "configurePreset": "circleci",
+      "configuration": "MinSizeRel",
+      "output": { "outputOnFailure": true},
+      "execution": {"jobs": 3},
+      "environment": {
+        "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS": "2"
+      }
+    },
+    {
+      "name": "azure",
+      "configurePreset": "azure",
+      "configuration": "MinSizeRel",
+      "output": {
+        "verbosity": "extra"
+      },
+      "execution": {"jobs": 4},
+      "environment": { }
+    }
+  ]
+}


### PR DESCRIPTION
CMake released a relatively new presets feature that allows for the configuration of environment and cmake variables within a JSON file. This allows build environments to be quickly replicated between users and systems.

This change creates basic support for CMake presets and includes presets mimicking the environments used for our Azure and CircleCI test builds. 