### PR TITLE
STYLE: Prefer explicit const designation

### DIFF
--- a/Modules/Core/Common/include/itkDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkDerivativeOperator.hxx
@@ -36,11 +36,11 @@ DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Co
     unsigned int  j = 1;
     for (; j < w - 1; ++j)
     {
-      PixelRealType next = coeff[j - 1] + coeff[j + 1] - 2 * coeff[j];
+      const PixelRealType next = coeff[j - 1] + coeff[j + 1] - 2 * coeff[j];
       coeff[j - 1] = previous;
       previous = next;
     }
-    PixelRealType next = coeff[j - 1] - 2 * coeff[j];
+    const PixelRealType next = coeff[j - 1] - 2 * coeff[j];
     coeff[j - 1] = previous;
     coeff[j] = next;
   }
@@ -50,11 +50,11 @@ DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Co
     unsigned int  j = 1;
     for (; j < w - 1; ++j)
     {
-      PixelRealType next = -0.5 * coeff[j - 1] + 0.5 * coeff[j + 1];
+      const PixelRealType next = -0.5 * coeff[j - 1] + 0.5 * coeff[j + 1];
       coeff[j - 1] = previous;
       previous = next;
     }
-    PixelRealType next = -0.5 * coeff[j - 1];
+    const PixelRealType next = -0.5 * coeff[j - 1];
     coeff[j - 1] = previous;
     coeff[j] = next;
   }

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
@@ -122,7 +122,7 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
         IndexType tempIndex;
         for (unsigned int i = 0; i < dim; ++i)
         {
-          unsigned int counterCopy = counter;
+          const unsigned int counterCopy = counter;
           tempIndex[i] = index[i] + static_cast<int>((counterCopy >> i) & 0x0001);
         }
 
@@ -164,7 +164,7 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
         IndexType tempIndex;
         for (unsigned int i = 0; i < dim; ++i)
         {
-          unsigned int counterCopy = counter;
+          const unsigned int counterCopy = counter;
           tempIndex[i] = index[i] + static_cast<int>((counterCopy >> i) & 0x0001);
         }
 

--- a/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
@@ -45,7 +45,7 @@ itkArchetypeSeriesFileNamesTest(int argc, char * argv[])
     fit->SetArchetype(archetype);
     ITK_TEST_SET_GET_VALUE(archetype, fit->GetArchetype());
 
-    std::vector<std::string> names = fit->GetFileNames();
+    const std::vector<std::string> names = fit->GetFileNames();
 
     std::cout << "List of returned filenames: " << std::endl;
     for (auto & name : names)

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -566,7 +566,7 @@ MetaImageIO::WriteImageInformation()
 
   // Save out the metadatadictionary key/value pairs as part of
   // the metaio header.
-  std::vector<std::string> keys = metaDict.GetKeys();
+  const std::vector<std::string> keys = metaDict.GetKeys();
   for (auto & key : keys)
   {
     if (key == ITK_ExperimentDate || key == ITK_VoxelUnits)

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -255,8 +255,8 @@ Histogram<TMeasurement, TFrequencyContainer>::GetIndex(const MeasurementVectorTy
 
   for (unsigned int dim = 0; dim < measurementVectorSize; ++dim)
   {
-    MeasurementType tempMeasurement = measurement[dim];
-    IndexValueType  begin = 0;
+    const MeasurementType tempMeasurement = measurement[dim];
+    IndexValueType        begin = 0;
     if (tempMeasurement < m_Min[dim][begin])
     {
       // one of measurement is below the minimum

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -558,19 +558,19 @@ DownHeap(TSubsample * sample, unsigned int activeDimension, int beginIndex, int 
   while (true)
   {
     // location of first child
-    int largerChild = beginIndex + 2 * (currentNode - beginIndex) + 1;
-    int leftChild = largerChild;
-    int rightChild = leftChild + 1;
+    int       largerChild = beginIndex + 2 * (currentNode - beginIndex) + 1;
+    const int leftChild = largerChild;
+    const int rightChild = leftChild + 1;
     if (leftChild > endIndex - 1)
     {
       // leaf node
       return;
     }
 
-    const auto            initValue = sample->GetMeasurementVectorByIndex(leftChild)[activeDimension];
-    SampleMeasurementType leftChildValue = initValue;
-    SampleMeasurementType rightChildValue = initValue;
-    SampleMeasurementType largerChildValue = initValue;
+    const auto                  initValue = sample->GetMeasurementVectorByIndex(leftChild)[activeDimension];
+    const SampleMeasurementType leftChildValue = initValue;
+    SampleMeasurementType       rightChildValue = initValue;
+    SampleMeasurementType       largerChildValue = initValue;
 
     if (rightChild < endIndex)
     {
@@ -633,14 +633,15 @@ IntrospectiveSortLoop(TSubsample * sample,
     }
 
     --depthLimit;
-    int cut = Partition<TSubsample>(sample,
-                                    activeDimension,
-                                    beginIndex,
-                                    endIndex,
-                                    MedianOfThree<SampleMeasurementType>(
-                                      sample->GetMeasurementVectorByIndex(beginIndex)[activeDimension],
-                                      sample->GetMeasurementVectorByIndex(beginIndex + length / 2)[activeDimension],
-                                      sample->GetMeasurementVectorByIndex(endIndex - 1)[activeDimension]));
+    const int cut =
+      Partition<TSubsample>(sample,
+                            activeDimension,
+                            beginIndex,
+                            endIndex,
+                            MedianOfThree<SampleMeasurementType>(
+                              sample->GetMeasurementVectorByIndex(beginIndex)[activeDimension],
+                              sample->GetMeasurementVectorByIndex(beginIndex + length / 2)[activeDimension],
+                              sample->GetMeasurementVectorByIndex(endIndex - 1)[activeDimension]));
     IntrospectiveSortLoop<TSubsample>(sample, activeDimension, cut, endIndex, depthLimit, sizeThreshold);
     endIndex = cut;
     length = endIndex - beginIndex;


### PR DESCRIPTION
Implements detection of local variables which could be declared as const but
are not. Declaring variables as const is recommended by many coding
guidelines, such as: ES.25 from the C++ Core Guidelines.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,misc-const-correctness -header-filter=.* -fix
