### PR TITLE
PERF: Replace explicit return calls of constructor

### DIFF
--- a/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
+++ b/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
@@ -83,9 +83,9 @@ AnatomicalOrientation::CreateFromPositiveStringEncoding(std::string str)
   auto                                                                        iter = stringToCode.find(str);
   if (iter == stringToCode.end())
   {
-    return AnatomicalOrientation(PositiveEnum::INVALID);
+    return { PositiveEnum::INVALID };
   }
-  return AnatomicalOrientation(iter->second);
+  return { iter->second };
 }
 
 AnatomicalOrientation

--- a/Modules/Core/Common/src/itkNumberToString.cxx
+++ b/Modules/Core/Common/src/itkNumberToString.cxx
@@ -56,7 +56,7 @@ FloatingPointNumberToString(const TValue val)
   {
     itkGenericExceptionMacro("Conversion failed for " << val);
   }
-  return std::string(builder.Finalize());
+  return { builder.Finalize() };
 }
 
 } // namespace

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1051,7 +1051,7 @@ ProcessObject::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
 {
   if (idx < ITK_GLOBAL_INDEX_NAMES_NUMBER)
   {
-    return ProcessObject::DataObjectIdentifierType(globalIndexNames[idx]);
+    return { globalIndexNames[idx] };
   }
   else
   {

--- a/Modules/Core/Common/test/itkSmartPointerTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerTest.cxx
@@ -73,7 +73,7 @@ private:
 itkTestObject::Pointer
 itkTestObject::New()
 {
-  return itkTestObject::Pointer(new itkTestObject);
+  return { new itkTestObject };
 }
 
 class itkTestObjectSubClass : public itkTestObject
@@ -88,7 +88,7 @@ public:
 itkTestObjectSubClass::Pointer
 itkTestObjectSubClass::New()
 {
-  return itkTestObjectSubClass::Pointer(new itkTestObjectSubClass);
+  return { new itkTestObjectSubClass };
 }
 
 // This SHOULD NOT be used in ITK, all functions

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -55,16 +55,16 @@ DTITubeSpatialObjectPoint<TPointDimension>::TranslateEnumToChar(DTITubeSpatialOb
   switch (static_cast<int>(name))
   {
     case 0:
-      return std::string("FA");
+      return { "FA" };
     case 1:
-      return std::string("ADC");
+      return { "ADC" };
     case 2:
-      return std::string("GA");
+      return { "GA" };
     default:
       // Just fall through.
       break;
   }
-  return std::string("");
+  return { "" };
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -66,23 +66,23 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType & itkNotUsed(vector)) const override
   {
-    return OutputVectorType();
+    return {};
   }
   OutputVnlVectorType
   TransformVector(const InputVnlVectorType & itkNotUsed(vector)) const override
   {
-    return OutputVnlVectorType();
+    return {};
   }
   OutputVectorPixelType
   TransformVector(const InputVectorPixelType & itkNotUsed(inputPixel),
                   const InputPointType &       itkNotUsed(inputPoint)) const override
   {
-    return OutputVectorPixelType();
+    return {};
   }
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType & itkNotUsed(vector)) const override
   {
-    return OutputCovariantVectorType();
+    return {};
   }
   void
   ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType &) const override

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -395,12 +395,12 @@ ImageIOBase::GetFileTypeAsString(IOFileEnum t) const
   switch (t)
   {
     case IOFileEnum::ASCII:
-      return std::string("ASCII");
+      return { "ASCII" };
     case IOFileEnum::Binary:
-      return std::string("Binary");
+      return { "Binary" };
     case IOFileEnum::TypeNotApplicable:
     default:
-      return std::string("TypeNotApplicable");
+      return { "TypeNotApplicable" };
   }
   // Not reachable return s = "TypeNotApplicable";
 }
@@ -411,12 +411,12 @@ ImageIOBase::GetByteOrderAsString(IOByteOrderEnum t) const
   switch (t)
   {
     case IOByteOrderEnum::BigEndian:
-      return std::string("BigEndian");
+      return { "BigEndian" };
     case IOByteOrderEnum::LittleEndian:
-      return std::string("LittleEndian");
+      return { "LittleEndian" };
     case IOByteOrderEnum::OrderNotApplicable:
     default:
-      return std::string("OrderNotApplicable");
+      return { "OrderNotApplicable" };
   }
 }
 
@@ -426,33 +426,33 @@ ImageIOBase::GetComponentTypeAsString(IOComponentEnum t)
   switch (t)
   {
     case IOComponentEnum::UCHAR:
-      return std::string("unsigned_char");
+      return { "unsigned_char" };
     case IOComponentEnum::CHAR:
-      return std::string("char");
+      return { "char" };
     case IOComponentEnum::USHORT:
-      return std::string("unsigned_short");
+      return { "unsigned_short" };
     case IOComponentEnum::SHORT:
-      return std::string("short");
+      return { "short" };
     case IOComponentEnum::UINT:
-      return std::string("unsigned_int");
+      return { "unsigned_int" };
     case IOComponentEnum::INT:
-      return std::string("int");
+      return { "int" };
     case IOComponentEnum::ULONG:
-      return std::string("unsigned_long");
+      return { "unsigned_long" };
     case IOComponentEnum::LONG:
-      return std::string("long");
+      return { "long" };
     case IOComponentEnum::ULONGLONG:
-      return std::string("unsigned_long_long");
+      return { "unsigned_long_long" };
     case IOComponentEnum::LONGLONG:
-      return std::string("long_long");
+      return { "long_long" };
     case IOComponentEnum::FLOAT:
-      return std::string("float");
+      return { "float" };
     case IOComponentEnum::DOUBLE:
-      return std::string("double");
+      return { "double" };
     case IOComponentEnum::UNKNOWNCOMPONENTTYPE:
-      return std::string("unknown");
+      return { "unknown" };
     default:
-      return std::string("unknown");
+      return { "unknown" };
   }
 }
 
@@ -519,33 +519,33 @@ ImageIOBase::GetPixelTypeAsString(IOPixelEnum t)
   switch (t)
   {
     case IOPixelEnum::SCALAR:
-      return std::string("scalar");
+      return { "scalar" };
     case IOPixelEnum::VECTOR:
-      return std::string("vector");
+      return { "vector" };
     case IOPixelEnum::COVARIANTVECTOR:
-      return std::string("covariant_vector");
+      return { "covariant_vector" };
     case IOPixelEnum::POINT:
-      return std::string("point");
+      return { "point" };
     case IOPixelEnum::OFFSET:
-      return std::string("offset");
+      return { "offset" };
     case IOPixelEnum::RGB:
-      return std::string("rgb");
+      return { "rgb" };
     case IOPixelEnum::RGBA:
-      return std::string("rgba");
+      return { "rgba" };
     case IOPixelEnum::SYMMETRICSECONDRANKTENSOR:
-      return std::string("symmetric_second_rank_tensor");
+      return { "symmetric_second_rank_tensor" };
     case IOPixelEnum::DIFFUSIONTENSOR3D:
-      return std::string("diffusion_tensor_3D");
+      return { "diffusion_tensor_3D" };
     case IOPixelEnum::COMPLEX:
-      return std::string("complex");
+      return { "complex" };
     case IOPixelEnum::FIXEDARRAY:
-      return std::string("fixed_array");
+      return { "fixed_array" };
     case IOPixelEnum::MATRIX:
-      return std::string("matrix");
+      return { "matrix" };
     case IOPixelEnum::UNKNOWNPIXELTYPE:
-      return std::string("unknown");
+      return { "unknown" };
     default:
-      return std::string("unknown");
+      return { "unknown" };
   }
 }
 

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -96,15 +96,15 @@ MeshIOBase::GetFileTypeAsString(IOFileEnum t) const
   switch (t)
   {
     case IOFileEnum::ASCII:
-      return std::string("ASCII");
+      return { "ASCII" };
     case IOFileEnum::BINARY:
-      return std::string("BINARY");
+      return { "BINARY" };
     case IOFileEnum::TYPENOTAPPLICABLE:
       break;
     default:
       break;
   }
-  return std::string("TYPENOTAPPLICABLE");
+  return { "TYPENOTAPPLICABLE" };
 }
 
 std::string
@@ -113,15 +113,15 @@ MeshIOBase::GetByteOrderAsString(IOByteOrderEnum t) const
   switch (t)
   {
     case IOByteOrderEnum::BigEndian:
-      return std::string("BigEndian");
+      return { "BigEndian" };
     case IOByteOrderEnum::LittleEndian:
-      return std::string("LittleEndian");
+      return { "LittleEndian" };
     case IOByteOrderEnum::OrderNotApplicable:
       break;
     default:
       break;
   }
-  return std::string("OrderNotApplicable");
+  return { "OrderNotApplicable" };
 }
 
 std::string
@@ -130,33 +130,33 @@ MeshIOBase::GetComponentTypeAsString(IOComponentEnum t) const
   switch (t)
   {
     case IOComponentEnum::UCHAR:
-      return std::string("unsigned_char");
+      return { "unsigned_char" };
     case IOComponentEnum::CHAR:
-      return std::string("char");
+      return { "char" };
     case IOComponentEnum::USHORT:
-      return std::string("unsigned_short");
+      return { "unsigned_short" };
     case IOComponentEnum::SHORT:
-      return std::string("short");
+      return { "short" };
     case IOComponentEnum::UINT:
-      return std::string("unsigned_int");
+      return { "unsigned_int" };
     case IOComponentEnum::INT:
-      return std::string("int");
+      return { "int" };
     case IOComponentEnum::ULONG:
-      return std::string("unsigned_long");
+      return { "unsigned_long" };
     case IOComponentEnum::LONG:
-      return std::string("long");
+      return { "long" };
     case IOComponentEnum::LONGLONG:
-      return std::string("long_long");
+      return { "long_long" };
     case IOComponentEnum::ULONGLONG:
-      return std::string("unsigned_long_long");
+      return { "unsigned_long_long" };
     case IOComponentEnum::FLOAT:
-      return std::string("float");
+      return { "float" };
     case IOComponentEnum::DOUBLE:
-      return std::string("double");
+      return { "double" };
     case IOComponentEnum::LDOUBLE:
-      return std::string("long_double");
+      return { "long_double" };
     case IOComponentEnum::UNKNOWNCOMPONENTTYPE:
-      return std::string("unknown");
+      return { "unknown" };
     default:
       break;
   }
@@ -169,37 +169,37 @@ MeshIOBase::GetPixelTypeAsString(IOPixelEnum t) const
   switch (t)
   {
     case IOPixelEnum::SCALAR:
-      return std::string("scalar");
+      return { "scalar" };
     case IOPixelEnum::VECTOR:
-      return std::string("vector");
+      return { "vector" };
     case IOPixelEnum::COVARIANTVECTOR:
-      return std::string("covariant_vector");
+      return { "covariant_vector" };
     case IOPixelEnum::POINT:
-      return std::string("point");
+      return { "point" };
     case IOPixelEnum::OFFSET:
-      return std::string("offset");
+      return { "offset" };
     case IOPixelEnum::RGB:
-      return std::string("rgb");
+      return { "rgb" };
     case IOPixelEnum::RGBA:
-      return std::string("rgba");
+      return { "rgba" };
     case IOPixelEnum::SYMMETRICSECONDRANKTENSOR:
-      return std::string("symmetric_second_rank_tensor");
+      return { "symmetric_second_rank_tensor" };
     case IOPixelEnum::DIFFUSIONTENSOR3D:
-      return std::string("diffusion_tensor_3D");
+      return { "diffusion_tensor_3D" };
     case IOPixelEnum::COMPLEX:
-      return std::string("complex");
+      return { "complex" };
     case IOPixelEnum::FIXEDARRAY:
-      return std::string("fixed_array");
+      return { "fixed_array" };
     case IOPixelEnum::ARRAY:
-      return std::string("array");
+      return { "array" };
     case IOPixelEnum::MATRIX:
-      return std::string("matrix");
+      return { "matrix" };
     case IOPixelEnum::VARIABLELENGTHVECTOR:
-      return std::string("variable_length_vector");
+      return { "variable_length_vector" };
     case IOPixelEnum::VARIABLESIZEMATRIX:
-      return std::string("variable_size_matrix");
+      return { "variable_size_matrix" };
     case IOPixelEnum::UNKNOWNPIXELTYPE:
-      return std::string("unknown");
+      return { "unknown" };
     default:
       break;
   }

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -165,7 +165,7 @@ public:
   static std::string
   ZeroValue()
   {
-    return std::string("");
+    return { "" };
   }
 };
 

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -206,14 +206,14 @@ template <>
 inline std::string
 TransformIOBaseTemplate<float>::GetTypeNameString()
 {
-  return std::string("float");
+  return { "float" };
 }
 
 template <>
 inline std::string
 TransformIOBaseTemplate<double>::GetTypeNameString()
 {
-  return std::string("double");
+  return { "double" };
 }
 
 /** This helps to meet backward compatibility */

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -316,7 +316,7 @@ LBFGSOptimizer::GetStopConditionDescription() const
   }
   else
   {
-    return std::string("");
+    return { "" };
   }
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -214,7 +214,7 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetStopConditionDescription() c
   }
   else
   {
-    return std::string("");
+    return { "" };
   }
 }
 

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
@@ -138,7 +138,7 @@ public:
   StopConditionReturnStringType
   GetStopConditionDescription() const override
   {
-    return std::string("Placeholder test return string");
+    return { "Placeholder test return string" };
   }
 };
 


### PR DESCRIPTION
Replaces explicit calls to the constructor in a return with a braced
initializer list. This way the return type is not needlessly duplicated in the
function definition and the return statement.
