### PR TITLE
STYLE: Use override statements for C++11

### DIFF
--- a/Modules/Core/Common/include/itkPyCommand.h
+++ b/Modules/Core/Common/include/itkPyCommand.h
@@ -75,7 +75,7 @@ public:
 
 protected:
   PyCommand();
-  ~PyCommand();
+  ~PyCommand() override;
   void
   PyExecute();
   PyCommand(const Self &); // Not implemented.

--- a/Modules/Core/Common/include/itkPyImageFilter.h
+++ b/Modules/Core/Common/include/itkPyImageFilter.h
@@ -103,7 +103,7 @@ public:
 
 protected:
   PyImageFilter();
-  virtual ~PyImageFilter();
+  ~PyImageFilter() override;
 
   void
   GenerateInputRequestedRegion() override;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -140,7 +140,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual typename LightObject::Pointer
+  typename LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -245,7 +245,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual void
+  void
   VerifyPreconditions() const override;
 
   void

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
@@ -67,7 +67,7 @@ protected:
     Superclass::SetFunctor(FunctorType());
 #endif
   }
-  virtual ~TernaryAddImageFilter() = default;
+  ~TernaryAddImageFilter() override = default;
 };
 } // end namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
@@ -56,11 +56,11 @@ public:
 
 protected:
   DiscreteCurvatureTensorQuadEdgeMeshFilter() = default;
-  ~DiscreteCurvatureTensorQuadEdgeMeshFilter() = default;
+  ~DiscreteCurvatureTensorQuadEdgeMeshFilter() override = default;
 
   /// TODO to be implemented
-  virtual void
-  GenerateData()
+  void
+  GenerateData() override
   {}
 };
 } // namespace itk

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -273,7 +273,7 @@ public:
   {}
 
   InputCoordinateType
-  operator()(const InputMeshType * iMesh, InputQEType * iEdge) const
+  operator()(const InputMeshType * iMesh, InputQEType * iEdge) const override
   {
     const AuthalicMatrixCoefficients<TInputMesh>  authalic;
     const ConformalMatrixCoefficients<TInputMesh> conformal;

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -214,7 +214,7 @@ public:
   void
   ResumeOptimization() override;
 
-  virtual StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
   /**


### PR DESCRIPTION
Describe function overrides using the override keyword from C++11.

-----
https://stackoverflow.com/questions/39932391/virtual-override-or-both-c
When you override a function you don't technically need to write either virtual
or override.

The original base class declaration needs the keyword virtual to mark it as
virtual.

In the derived class the function is virtual by way of having the ¹same type as
the base class function.

However, an override can help avoid bugs by producing a compilation error when
the intended override isn't technically an override. For instance, the function
type isn't exactly like the base class function. Or that a maintenance of the
base class changes that function's type, e.g. adding a defaulted argument.

In the same way, a virtual keyword in the derived class can make such a bug
more subtle by ensuring that the function is still virtual in the further
derived classes.

So the general advice is,

Use virtual for the base class function declaration.  This is technically
necessary.

Use override (only) for a derived class' override.  This helps maintenance.
-----

Remove 'virtual' is implied when 'override' is specified, so remove the
redundant specification.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-override  -header-filter=.* -fix
