### PR TITLE
update remote modules ITKv6 support

### DIFF
--- a/Modules/Remote/AdaptiveDenoising.remote.cmake
+++ b/Modules/Remote/AdaptiveDenoising.remote.cmake
@@ -57,5 +57,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/ntustison/ITKAdaptiveDenoising.git
-  GIT_TAG 9a7adca1a822589c66a176a9e093d8a9f1c222c2
+  GIT_TAG b355f99ffd443096c865684499d57a8bd9fb108e
   )

--- a/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   "AnalyzeObjectLabelMap plugin for ITK. From Insight Journal article with handle: https://doi.org/10.54294/w2jytv"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG 513b909271f6e90251d633e25c28d8b5f4becf37
+  GIT_TAG d4b8c78525dba8b6e05581bdafe090c2513ac93b
   )

--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -64,5 +64,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG 1e4a4e9bac1f40058dd57abc7a49443d9ac6376b
+  GIT_TAG 0aa8dae3b86b045940b3a18c323f50d260f33c38
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Approximate an image's gradient from a b-spline fit to its intensity."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG 73dcf827d76bbf2a36d08784d421b234fb630c80
+  GIT_TAG 37d282773c44d421a899c849b10be51a0fba59d7
   )

--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -49,5 +49,5 @@ It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG de7ba0f0a205294f307000be3a7fdd03327abdb7
+  GIT_TAG 8fdd6a19f3a22f33c4970899c404ea77a7da08ab
   )

--- a/Modules/Remote/BoneEnhancement.remote.cmake
+++ b/Modules/Remote/BoneEnhancement.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Various filters for enhancing cortical bones in quantitative computed tomography."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneEnhancement.git
-  GIT_TAG d6f6649c9ba0c96612d6868d161ea7c13dd34603
+  GIT_TAG 50b6df1afa33d53a27de2d159941f6f2be22e744
   )

--- a/Modules/Remote/BoneMorphometry.remote.cmake
+++ b/Modules/Remote/BoneMorphometry.remote.cmake
@@ -52,5 +52,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
-  GIT_TAG 47b8f352fb2cb7204d7a8b332847da438f268b35
+  GIT_TAG e47ba7144271d51578996f42b01340f67a66934b
   )

--- a/Modules/Remote/Cleaver.remote.cmake
+++ b/Modules/Remote/Cleaver.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK module wrapping Cleaver functionalities used for MultiMaterial Tetrahedral Meshing."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SCIInstitute/ITKCleaver.git
-  GIT_TAG 249b2710c093a8f62c5e0cdbab728eebaba5b693
+  GIT_TAG 721901c61eb91ba0ef8c44a5fa86b520ad153465
   )

--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -68,5 +68,5 @@ And the related:
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 3b35bb2f3d8fb5ac5b1bece93f2cbd61f9208952
+  GIT_TAG 575879cd5cde59c650ce442e93c0507bb9a295ee
   )

--- a/Modules/Remote/CudaCommon.remote.cmake
+++ b/Modules/Remote/CudaCommon.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Framework for processing images with Cuda."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/ITKCudaCommon.git
-  GIT_TAG cae7c93c2f6d4c5b3cb5f6e5ce4a97686e626bf7
+  GIT_TAG b77d5b2719d16b3d1983a86cdb46e09fc4e14dd8
   )

--- a/Modules/Remote/FPFH.remote.cmake
+++ b/Modules/Remote/FPFH.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/InsightSoftwareConsortium/ITKFPFH
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFPFH.git
-  GIT_TAG fc59b2e17b0417b7d4385d2b38280232eae4d449
+  GIT_TAG c5fd21e320266a0e890fc8afb17b5bfe95a3196a
   )

--- a/Modules/Remote/FastBilateral.remote.cmake
+++ b/Modules/Remote/FastBilateral.remote.cmake
@@ -50,5 +50,5 @@ Insight Journal article:
 https://doi.org/10.54294/noo5vc"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFastBilateral.git
-  GIT_TAG e37be230b50c6934b0c260c2ffec8092bf54f498
+  GIT_TAG 76c01873194a5839ca2a82de4ad9778e0adf2d6d
   )

--- a/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
+++ b/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Computes the inverse of a displacement field."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField.git
-  GIT_TAG 6f158a7e921b02f6315311ef2e79e280a0eb83a0
+  GIT_TAG 2cde8ef941f5dce8870ec3c4d73d97530742c2e4
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A generic interpolator for multi-label images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG ebf2436469ccf82c08fab54b7446f699ad0eae01
+  GIT_TAG 5405b036ebf05addd5688d18fab7dade4acc9c93
   )

--- a/Modules/Remote/GrowCut.remote.cmake
+++ b/Modules/Remote/GrowCut.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITKGrowCut segments a 3D image from user-provided foreground and background seeds."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGrowCut.git
-  GIT_TAG da8597a31ae47b5a9d549ef095a32aa3bdb0d6bc
+  GIT_TAG 79a884ccf7dd399ddb0a1237c8bb878c34275862
   )

--- a/Modules/Remote/HASI.remote.cmake
+++ b/Modules/Remote/HASI.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "High-throughput Applications for Skeletal Imaging."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/HASI.git
-  GIT_TAG c736a15b2f076b36f80723af23638fb7e854b63b
+  GIT_TAG a0c7a042af83df516a1c8c56191b9388f9151984
   )

--- a/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
+++ b/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   https://doi.org/10.54294/zv7979"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient.git
-  GIT_TAG ffb1cd47ddea117e3bc76ee075415efb784afd41
+  GIT_TAG bd6a2b2b6917af6450bd287d0f920e0e68bf301f
   )

--- a/Modules/Remote/IOFDF.remote.cmake
+++ b/Modules/Remote/IOFDF.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "FDFImageIO plugin for ITK. Authors Gleen Pierce/Nick Tustison/Kent Williams"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOFDF.git
-  GIT_TAG 1570924e00090dccf31493f9274202455a51add4
+  GIT_TAG ec1c8c8478364ce0042d6a33d4b74ace4d43bdac
   )

--- a/Modules/Remote/IOMeshSTL.remote.cmake
+++ b/Modules/Remote/IOMeshSTL.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   the STL (STereoLithography) file format. https://doi.org/10.54294/7rr2te"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshSTL.git
-  GIT_TAG cf5e0b7625704c81bdcde53f2515571632ad39ec
+  GIT_TAG 06e3030542ae567a40d60f21c6606747f3ce28f2
   )

--- a/Modules/Remote/IOMeshSWC.remote.cmake
+++ b/Modules/Remote/IOMeshSWC.remote.cmake
@@ -47,6 +47,6 @@ itk_fetch_module(
   "Read meshes from SWC files, a format for representing neuron morphology."
   MODULE_COMPLIANCE_LEVEL 4
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshSWC.git
-  GIT_TAG 6cc788b6f677d95e0e23080d0457fede2ade2e97
+  GIT_TAG 2009bb006ea8e2cc1eb279c50a6f3c937e20322e
   )
 mark_as_advanced(FORCE Module_IOMeshSWC)

--- a/Modules/Remote/IOOpenSlide.remote.cmake
+++ b/Modules/Remote/IOOpenSlide.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "ITK ImageIO for OpenSlide library supported file formats. These are generally TIFF-based microscopy formats."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOOpenSlide.git
-  GIT_TAG 2d7af237f872dd6f8171d2d09b843bc3cbe694a2
+  GIT_TAG 16397a9000be3623990a0c27f5eacb53dc8559f5
   )

--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKIOScanco.git
-  GIT_TAG 10b80f69048e79ab3069e89635822a6851099278
+  GIT_TAG 7b551e4b2eb162dddfbd409491c4f53ec993b207
   )

--- a/Modules/Remote/IOTransformDCMTK.remote.cmake
+++ b/Modules/Remote/IOTransformDCMTK.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   files. See https://doi.org/10.54294/lf8u753"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOTransformDCMTK.git
-  GIT_TAG 3111018eb241e5e90b5923413372f1adbcb34b0d
+  GIT_TAG 83cd5c89df4b17a8307e1a408701a1d4256d75f9
   )

--- a/Modules/Remote/IsotropicWavelets.remote.cmake
+++ b/Modules/Remote/IsotropicWavelets.remote.cmake
@@ -54,5 +54,5 @@ Cerdan, P.H. \"Steerable Isotropic Wavelets for Multiscale and Phase Analysis\".
   # Upstream repository was transferred from phcerdan to InsightSoftwareConsortium
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets.git
-  GIT_TAG 9dc0f58fdf76842b0cb88e4898da5314292c13d5
+  GIT_TAG f8380aec79623baa3d84c9baa6b343af914fbfd8
   )

--- a/Modules/Remote/LabelErodeDilate.remote.cmake
+++ b/Modules/Remote/LabelErodeDilate.remote.cmake
@@ -53,5 +53,5 @@ itk_fetch_module(
   MODULE_COMPLIANCE_LEVEL 2
   #UPSTREAM_GIT_REPOSITORY
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate.git
-  GIT_TAG 7e23b12be913ff2bd935d9ffc2d10b573a923501
+  GIT_TAG 91137778c5364275dcc3d7ff10610479890527a8
   )

--- a/Modules/Remote/LesionSizingToolkit.remote.cmake
+++ b/Modules/Remote/LesionSizingToolkit.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Framework for determining the sizes of lesions in medical images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/LesionSizingToolkit.git
-  GIT_TAG 67a91c0cba44b35a443f6fd6e2d46695c4f7ff9c
+  GIT_TAG 75b6099812b3f057c00bf114b4e1e0814105d7cd
   )

--- a/Modules/Remote/MGHIO.remote.cmake
+++ b/Modules/Remote/MGHIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "MGHIO ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkMGHImageIO.git
-  GIT_TAG a3a970296f72a3fa7fa496e4370fb7d2feb9311d
+  GIT_TAG 969f1827d92ddac18339e9a4d9120fea0e2bc916
   )

--- a/Modules/Remote/MeshNoise.remote.cmake
+++ b/Modules/Remote/MeshNoise.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshNoise.git
-  GIT_TAG 2b2ccb53f7eb0fb03034cc89ac6793e35e2427c2
+  GIT_TAG 47e683f88ac4d36e490ce7afe4fad4c6053b1204
   )

--- a/Modules/Remote/MeshToPolyData.remote.cmake
+++ b/Modules/Remote/MeshToPolyData.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Convert an ITK Mesh to a data structure compatible with vtkPolyData."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData.git
-  GIT_TAG 7c9812527af5e061510ed5f5709da191a50e122a
+  GIT_TAG d90e542771e88b8ab9c3959881a730c175ef2cbd
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -48,6 +48,6 @@ itk_fetch_module(
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG e43a18f43272bea8c9de5ded7846efbffc81f0ad
+  GIT_TAG 17685d72037120d4483b9c72b4fb14c2bf90366b
   )
 # Release v1.2.6

--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG 9da9118a73e7875cb6e376324ccf521232c8aded
+  GIT_TAG b81b52385a58cf5ed4eda935a8abf0e8461dc09f
   )

--- a/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
+++ b/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
@@ -58,5 +58,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKMorphologicalContourInterpolation.git
-  GIT_TAG a0af585005fe2722ab5876f3a522eaa3122aad4e
+  GIT_TAG d04dd9cbe7b9d36bb60736844a63db2cb48aeae7
   )

--- a/Modules/Remote/ParabolicMorphology.remote.cmake
+++ b/Modules/Remote/ParabolicMorphology.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   https://doi.org/10.54294/aq68pt"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKParabolicMorphology.git
-  GIT_TAG 68286edc7459072eb33422a7d53c855318496922
+  GIT_TAG f728d2f79ad2dd401ab5665c0494c80a0e5101ed
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -59,5 +59,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG 6c7c21413da6c0760b86ed28513d404bb5a347de
+  GIT_TAG d833f53eb79da23c742e42741012491013e9ce06
   )

--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -55,5 +55,5 @@ https://doi.org/10.54294/gcb82u
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKPhaseSymmetry.git
-  GIT_TAG eb791a8ae9559469ec24fe4ccb49e8b8bd6c8dd3
+  GIT_TAG 9dc0df3af26ce20f9b0d8864cc014fd6a3e339d0
   )

--- a/Modules/Remote/PolarTransform.remote.cmake
+++ b/Modules/Remote/PolarTransform.remote.cmake
@@ -55,5 +55,5 @@ For more information, see the Insight Journal article:
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPolarTransform.git
-  GIT_TAG 930d44ac91d2994e4d604be67714f1ffb9cd065c
+  GIT_TAG 4ed87d7d896a9dacdf7b49c97af3e95ccb4a7ad5
   )

--- a/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
+++ b/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
@@ -52,5 +52,5 @@ A more detailed description can be found in the Insight Journal article:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPrincipalComponentsAnalysis.git
-  GIT_TAG 2f8d8bffb37fca8875a674465af5e3d902432f30
+  GIT_TAG 72cada2e64f23c10ee78a0f957fc30ce2e172f36
   )

--- a/Modules/Remote/RANSAC.remote.cmake
+++ b/Modules/Remote/RANSAC.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/InsightSoftwareConsortium/ITKRANSAC
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKRANSAC.git
-  GIT_TAG d4b29552431f471437f8ac1093f5fc3550995577
+  GIT_TAG 377bcd41fa485cbeebc7fa4b2162b50834828c59
   )

--- a/Modules/Remote/RLEImage.remote.cmake
+++ b/Modules/Remote/RLEImage.remote.cmake
@@ -53,5 +53,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKRLEImage.git
-  GIT_TAG 3ab10cda40977e4a39f9c46f1858f2fddcda8030
+  GIT_TAG 16ab6215556e570d1e24df6f5a3f4fc8f2773215
   )

--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Reconstruction Toolkit (RTK) https://www.openrtk.org/"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/RTK.git
-  GIT_TAG 870737fca5274f9247e7d79fd09b61233dc2d369
+  GIT_TAG a7aa063ff26581997ff29924218d62518f77f5e6
   )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/scifio/scifio-imageio.git
-  GIT_TAG 1054ece893ee072bdb8124c45ce207de00af280f
+  GIT_TAG 52c4f224299d1fcffec69c9cac4003e81ab0158e
   )

--- a/Modules/Remote/Shape.remote.cmake
+++ b/Modules/Remote/Shape.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM)."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SlicerSALT/ITKShape.git
-  GIT_TAG b5311e41f644aede86367f883e2d115d92b08e62
+  GIT_TAG f8a9b81a392070c8a9ac41549bcb4bbeec435ed2
   )

--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG 2216e1b31e9fcd52a3f4a4a24994d22a149db965
+  GIT_TAG 7c61cc8a6bf802802fe2f0fb61d2a33c85acf181
   )

--- a/Modules/Remote/SkullStrip.remote.cmake
+++ b/Modules/Remote/SkullStrip.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A class to perform automatic skull-stripping for neuroimage analysis."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSkullStrip.git
-  GIT_TAG 5cd3d23b5d59a5ff6c8ce885f1383a55ac9cf7b6
+  GIT_TAG 2719d4cf8bfc9773fb17a5c503a4c2523acef020
   )

--- a/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
+++ b/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   MODULE_COMPLIANCE_LEVEL 2
   #UPSTREAM_REPO GIT_REPOSITORY https://github.com/Inria-Asclepios/SmoothingRecursiveYvvGaussianFilter
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.git
-  GIT_TAG a9c08876d7d7288841d28b412f32c3521e9112e2
+  GIT_TAG fc7bb55430911b8d946cc1f2a7d6effd67b54665
   )

--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(
   "This module builds the examples found at https://itk.org/ITKExamples/"
   MODULE_COMPLIANCE_LEVEL 5
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSphinxExamples.git
-  GIT_TAG a63e366aaf3be3f10a1badf47c3180eefcec5edf
+  GIT_TAG 2a47f47756244e26f6ffe149534bda5acd45403d
   )

--- a/Modules/Remote/SplitComponents.remote.cmake
+++ b/Modules/Remote/SplitComponents.remote.cmake
@@ -50,5 +50,5 @@ itk::Image of, for example, itk::Vector, itk::CovariantVector, or
 itk::SymmetricSecondRankTensor. https://doi.org/10.54294/4c92vb"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSplitComponents.git
-  GIT_TAG 539fcd8faca472c760a567c041cb53c610cd9108
+  GIT_TAG 160755b8134bdab48fddf50805541f2b8dd05670
   )

--- a/Modules/Remote/Strain.remote.cmake
+++ b/Modules/Remote/Strain.remote.cmake
@@ -56,5 +56,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKStrain.git
-  GIT_TAG 8257ffc718c3a70222365977e2accbc55b567a88
+  GIT_TAG d1c52088ea6c32feda812bcd874c7c3313b49440
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -51,5 +51,5 @@ See the following Insight Journal's publication:
   https://doi.org/10.54294/vw0ke0"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG bc5a615da775128e009af2520b43bf0a38f60702
+  GIT_TAG 87d1e59d768f2b2b5ab0495fb8f927ce229409bb
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -57,5 +57,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG 99b5f66d72ef160faf1f46d4328a06217111101f
+  GIT_TAG 4ec7b93720bbdb9341f980b6ba699e95df72182c
   )

--- a/Modules/Remote/Thickness3D.remote.cmake
+++ b/Modules/Remote/Thickness3D.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Tools for 3D thickness measurement"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKThickness3D.git
-  GIT_TAG 866e25fefea4318240a90632acf3a12719d0416f
+  GIT_TAG de04753d4665838a77ebc3eba3c0ab2d4275987e
   )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG 0b4f9450f7c98b8db6dee5990bbd9be5d6e6c4d2
+  GIT_TAG fdc3acabfa7721626745a3a625a650c17d992904
   )

--- a/Modules/Remote/TubeTK.remote.cmake
+++ b/Modules/Remote/TubeTK.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   "http://www.tubetk.org"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTubeTK.git
-  GIT_TAG e29408eb2fa55ec21b9a9b8197f8a61ecbb3e5d1
+  GIT_TAG 1bdf1c4fb96161adac724f07e8eb7f8fe1978a99
   )

--- a/Modules/Remote/TwoProjectionRegistration.remote.cmake
+++ b/Modules/Remote/TwoProjectionRegistration.remote.cmake
@@ -62,5 +62,5 @@ Wu, J. \"ITK-Based Implementation of Two-Projection 2D/3D Registration Method wi
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTwoProjectionRegistration.git
-  GIT_TAG 7e995fcabd81f2e5099d582e5eec78702f8f4943
+  GIT_TAG 6029bebbe4cce9b7a779c19244ce787c5581b6d9
   )

--- a/Modules/Remote/Ultrasound.remote.cmake
+++ b/Modules/Remote/Ultrasound.remote.cmake
@@ -63,5 +63,5 @@ https://dx.doi.org/10.1109/ISBI.2016.7493437
 https://pdfs.semanticscholar.org/6bcd/1e7adbc24e15c928a7ad5af77bbd5da29c30.pdf"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKUltrasound.git
-  GIT_TAG 6d44d94896b3cf39f484ac38718579ed2d007e14
+  GIT_TAG e68b268910fa10947c4f1baf1920f696607249c4
   )

--- a/Modules/Remote/VariationalRegistration.remote.cmake
+++ b/Modules/Remote/VariationalRegistration.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   "A module to perform variational image registration. https://doi.org/10.54294/ts6kgm"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVariationalRegistration.git
-  GIT_TAG b8e3af90e9dea45fad7db81958ab2fd305a72b3e
+  GIT_TAG 559674ca54ff934ff7da3aa487df47f982a23cf5
   )

--- a/Modules/Remote/VkFFTBackend.remote.cmake
+++ b/Modules/Remote/VkFFTBackend.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK FFT accelerated backends using the VkFFT library for Vulkan/CUDA/HIP/OpenCL compatibility."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend.git
-  GIT_TAG 0d6863b3dfa4a7505c41585023b6f91ea2a07a7f
+  GIT_TAG ff700084925a0d5da072b13b672b7ab4740f2cb6
   )

--- a/Modules/Remote/WebAssemblyInterface.remote.cmake
+++ b/Modules/Remote/WebAssemblyInterface.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "The itk-wasm WebAssemblyInterface module provides tools to a) build C/C++ code to WebAssembly-compatible processing pipelines, b) bridge local filesystems, JavaScript/Typescript data structures, and traditional file formats, c) transfer data efficiently in and out of the WebAssembly runtime."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itk-wasm.git
-  GIT_TAG 5babcf68be5fdfdd689dce97779d2085103c0bc1
+  GIT_TAG e1f19f0bb2922dc708e322a28d79afa757d3fbaf
   )

--- a/Utilities/Maintenance/migrate-itk6-code-recommendations.sh
+++ b/Utilities/Maintenance/migrate-itk6-code-recommendations.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Update code to new macro names
+#
+# script for updating all the remote modules to update
+# to the latest ITK.
+# This script is also useful for updating other packages
+# 	BRAINSTools
+# 	ANTs
+# 	Slicer
+# 	....
+cat > /dev/null << EOF
+cd ~/Dashboard/src/ITK/Modules/Remote
+for gg in ~/Dashboard/src/ITK/Moudules/Remote/*/.git; do
+  cd $(dirname $gg)
+  bash  ~/Dashboard/src/ITK/Utilities/Maintenance/migrate-itk6-code-recommendations.sh $(pwd)
+  cd ~/Dashboard/src/ITK/Modules/Remote
+done
+EOF
+
+directory_to_convert=$(realpath $1)
+
+if [ ! -d "${directory_to_convert}" ]; then
+   echo "File to convert is missing: ${directory_to_convert}"
+   exit -1
+fi
+
+if [ "$(uname -s)" == "Darwin" ]; then
+	SEDBIN=gsed
+else
+	SEDBIN=sed
+fi
+
+cd "${directory_to_convert}"
+
+git remote -v |grep upstream
+has_upstream=$?
+if [ ${has_upstream} -eq 0 ]; then
+	primaryrepo="upstream"
+else
+	primaryrepo="upstream"
+fi
+
+git fetch origin
+git remote -v |grep upstream && git fetch upstream
+default_branch_name=$(git branch -l main master --format '%(refname:short)')
+git remote -v |grep upstream && git push origin upstream/${default_branch_name}:${default_branch_name} -f
+git fetch origin
+git rebase origin/${default_branch_name}
+
+files_modified=0
+for ff in $(git grep -l itkTypeMacro) $(git grep -l itkTypeMacroNoParent); do
+   echo "Modifying $ff"
+   ${SEDBIN} -i 's/itkTypeMacro *(\(.*\),.*) *;/itkOverrideGetNameOfClassMacro(\1);/g' "${ff}"
+   ${SEDBIN} -i 's/itkTypeMacroNoParent *(\(.*\),.*) *;/itkVirtualGetNameOfClassMacro(\1);/g' "${ff}"
+   git add ${ff}
+   files_modified=1
+done
+
+if [ ${files_modified} -ne 0 ] ; then
+git checkout -b update-to-new-macros
+
+git commit -m"STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro
+
+Added two new macro's, intended to replace the old 'itkTypeMacro' and
+'itkTypeMacroNoParent'.
+
+The main aim is to be clearer about what those macro's do: add a virtual
+'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
+'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
+was not used anyway.
+
+Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
+either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
+Schroeder, June 27, 2001:
+https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
+"
+
+gh pr create
+fi
+
+## Now change ITK_DISALLOW_COPY_AND_MOVE
+
+#Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE
+files_modified=0
+for ff in $(git grep -l ITK_DISALLOW_COPY_AND_ASSIGN); do
+   echo "Modifying $ff to update to ITK_DISALLOW_COPY_AND_MOVE"
+   ${SEDBIN} -i 's/ITK_DISALLOW_COPY_AND_ASSIGN/ITK_DISALLOW_COPY_AND_MOVE/g' "${ff}"
+   git add ${ff}
+   files_modified=1
+done
+
+if [ ${files_modified} -ne 0 ] ; then
+git checkout -b use-new-dissallow-copy-and-move
+
+git commit -m"STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE
+
+Clarifies that the macro does not just disallow copy and assign, but
+also move operations. Note that in this context, the term 'move' refers
+to both move-construct and move-assign.
+
+With this commit, the old macro name will remain available, as long as
+'ITK_FUTURE_LEGACY_REMOVE = OFF' (which is the default).
+"
+
+gh pr create
+fi
+
+## Now replace Replace itkStaticConstMacro with static constexpr
+
+files_modified=0
+for ff in $(git grep -l itkStaticConstMacro) $(git grep -l itkGetStaticConstMacro); do
+   echo "Modifying $ff to update to itkStaticConstMacro"
+   ${SEDBIN} -i 's/itkStaticConstMacro *( *\([^,]*\),[ \_s]*\([^,]*\),[ \_s]*\([^)]*\)) */static constexpr \2 \1 = \3/g' "${ff}"
+   ${SEDBIN} -i 's/itkGetStaticConstMacro *(\(.*\))/Self::\1/g' "${ff}"
+
+   git add ${ff}
+   files_modified=1
+done
+
+if [ ${files_modified} -ne 0 ] ; then
+git checkout -b replace-itkstaticconstmacro-with-constexpr
+
+git commit -m"STYLE: Replace itkStaticConstMacro with static constexpr
+
+Use static constexpr directly now that C++11 conformance
+is required by all compilers.
+
+:%s/itkStaticConstMacro *( *\([^,]*\),[ \_s]*\([^,]*\),\_s*\([^)]*\)) */static constexpr \2 \1 = \3/ge
+
+'itkStaticConstMacro(name, type, value)' became unconditionally
+identical to 'static constexpr type name = value' with ITK commit
+aec95193ab00e1322039911e1032da00f3a103b6 \"ENH: Update compiler macros (#810)\",
+maekclena, 7 May 2019.
+
+'itkGetStaticConstMacro(name)' became unconditionally identical to
+'(Self::name)' with ITK commit 84e490b81e3f3c2b0edb89ae7b9de53bfc52f2b2
+\"Removing some outdated compiler conditionals\", Hans Johnson, 31 July
+2010.
+
+Most 'itkStaticConstMacro' calls were removed by ITK commit 5c14741e1e063a132ea7e7ee69c5bd0a4e49af74
+"
+
+gh pr create
+fi
+
+## Now replace Replace ITKv5_CONST must be replaced with 'const'
+
+files_modified=0
+for ff in $(git grep -l ITKv5_CONST) $(git grep -l ITKv5_CONST); do
+   echo "Modifying $ff to update to ITKv5_CONST"
+   ${SEDBIN} -i 's/ITKv5_CONST/const/g' "${ff}"
+
+   git add ${ff}
+   files_modified=1
+done
+
+if [ ${files_modified} -ne 0 ] ; then
+git checkout -b replace_ITKv5_CONST-with-const
+
+git commit -m"ENH: ITKv5_CONST macro for VerifyPreconditions() and VerifyInputInformation()
+
+ITKv5_CONST enables backwards compatible behavior when ITKV4_COMPATIBILITY
+is turned ON for methods which have acquired 'const' qualifier in ITKv5.
+Breaking changes were originally introduced by ITK  commits
+3e6b6f5bd6772316aa0fa6b89f31b42bef562112 (on 2018-10-18) and
+16eae15c1bb6cc1bae9fba3e09a3102bdc02e955 (on 2018-10-23).
+"
+
+gh pr create
+fi
+
+## Now replace Replace Co
+
+files_modified=0
+for ff in $(git grep -l CoordRepType) $(git grep -l InputCoordRepType); do
+   echo "Modifying $ff to update to CoordinateType"
+   ${SEDBIN} -i 's/ImagePointCoordRepType/ImagePointCoordinateType/g' "${ff}"
+   ${SEDBIN} -i 's/InputCoordRepType/InputCoordinateType/g' "${ff}"
+   ${SEDBIN} -i 's/OutputCoordRepType/OutputCoordinateType/g' "${ff}"
+   ${SEDBIN} -i 's/CoordRepType/CoordinateType/g' "${ff}"
+
+   git add ${ff}
+   files_modified=1
+done
+
+if [ ${files_modified} -ne 0 ] ; then
+git checkout -b use-CoordinateType
+
+git commit -m"STYLE: CoordRepType -> CoordinateType code readability
+
+For the sake of code readability, a new 'CoordinateType' alias is added for
+each nested 'CoordRepType' alias. The old 'CoordRepType' aliases will still be
+available with ITK 6.0, but it is recommended to use 'CoordinateType' instead.
+The 'CoordRepType' aliases will be removed when 'ITK_FUTURE_LEGACY_REMOVE' is
+enabled. Similarly, 'InputCoordinateType', 'OutputCoordinateType', and
+'ImagePointCoordinateType' replace 'InputCoordRepType', 'OutputCoordRepType',
+and 'ImagePointCoordRepType', respectively.
+"
+
+gh pr create
+fi
+
+git branch -v |fgrep use-new-dissallow-copy-and-move:use-new-dissallow-copy-and-move && git push -f --set-upstream origin use-new-dissallow-copy-and-move:use-new-dissallow-copy-and-move
+git branch -v |fgrep update-to-new-macros:update-to-new-macros                       && git push -f --set-upstream origin update-to-new-macros:update-to-new-macros
+git branch -v |fgrep replace-itkstaticconstmacro-with-constexpr                      && git push -f --set-upstream origin replace-itkstaticconstmacro-with-constexpr
+git branch -v |fgrep replace_ITKv5_CONST-with-const                                  && git push -f --set-upstream origin replace_ITKv5_CONST-with-const
+git branch -v |fgrep use-CoordinateType                                              && git push -f --set-upstream origin use-CoordinateType


### PR DESCRIPTION
COMP: Update remote module hashes for ITKv6**

Allow building remote modules with ITK_FUTURE_LEGACY_REMOVE 
ITK_LEGACY_REMOVE turned ON.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
